### PR TITLE
Ticket3390 create ioc for reflectometers

### DIFF
--- a/example_beamline.py
+++ b/example_beamline.py
@@ -25,7 +25,7 @@ def create_beamline():
         [s0, s1, frame_overlap_mirror, polarising_mirror, s2, ideal_sample_point, s3, analyser, s4, detector],
         [theta])
     beamline.set_incoming_beam(beam_start)
-    beamline.mode = BeamlineMode("NR", ["theta"])
+    beamline.active_mode = BeamlineMode("NR", ["theta"])
 
     return beamline
 

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -63,8 +63,8 @@ def create_beamline():
     nr_inits = {"smenabled": False, "smangle": 0.0}
     pnr_inits = {"smenabled": True, "smangle": 0.5}
 
-    nr_mode = BeamlineMode("nr", params, nr_inits)
-    pnr_mode = BeamlineMode("pnr", [param for param in params if param.name is not "smangle"], pnr_inits)
+    nr_mode = BeamlineMode("nr", [param for param in PARAMS_FIELDS.keys() if param is not "smangle"], nr_inits)
+    pnr_mode = BeamlineMode("pnr", PARAMS_FIELDS.keys(), pnr_inits)
     disabled_mode = BeamlineMode("disabled", [])
 
     modes = [nr_mode, pnr_mode, disabled_mode]

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -1,0 +1,102 @@
+from pcaspy import SimpleServer
+from src.ChannelAccess.macros import *
+from src.components import *
+from src.beamline import Beamline, BeamlineMode
+from src.parameters import *
+from src.ChannelAccess.pv_server import ReflectometryDriver
+from src.ChannelAccess.pv_manager import PVManager
+
+STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["NO", "YES"]}
+FLOAT_PV_FIELDS = {'type': 'float', 'prec': 3, 'value': 0.0}
+PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
+                 "smangle": FLOAT_PV_FIELDS,
+                 "slit2pos": FLOAT_PV_FIELDS,
+                 "samplepos": FLOAT_PV_FIELDS,
+                 "theta": FLOAT_PV_FIELDS,
+                 "slit3pos": FLOAT_PV_FIELDS,
+                 "paenabled": STATUS_PV_FIELDS,
+                 "slit4pos": FLOAT_PV_FIELDS,
+                 "detpos": FLOAT_PV_FIELDS,
+                 }
+
+NR_INITS = {"smenabled": False, "smangle": 0.0}
+PNR_INITS = {"smenabled": True, "smangle": 0.5}
+
+NR_MODE = BeamlineMode("nr", PARAMS_FIELDS.keys(), NR_INITS)
+PNR_MODE = BeamlineMode("pnr", PARAMS_FIELDS.keys(), PNR_INITS)
+DISABLED_MODE = BeamlineMode("disabled", [])
+
+MODES = [NR_MODE, PNR_MODE, DISABLED_MODE]
+
+
+def create_beamline():
+    beam_angle_natural = -45
+    beam_start = PositionAndAngle(0.0, 0.0, beam_angle_natural)
+    perp_to_floor = 90.0
+
+    # COMPONENTS
+    # s1 = PassiveComponent("s1", LinearMovement(0.0, 7.3025, perp_to_beam_angle))
+    # s2 = PassiveComponent("s2", LinearMovement(0.0, 9.6885, perp_to_beam_angle))
+    # s3 = PassiveComponent("s3", LinearMovement(0.0, 10.651, perp_to_beam_angle))
+    # s4 = PassiveComponent("s4", LinearMovement(0.0, 11.983, perp_to_beam_angle))
+    # super_mirror = ActiveComponent("sm", LinearMovement(0.0, 7.7685, perp_to_beam_angle))
+    # sample = ActiveComponent("sample", LinearMovement(0.0, 10.25, perp_to_beam_angle))
+    # point_det = TiltingJaws("pdet", LinearMovement(0.0, 12.113, perp_to_beam_angle))
+    s1 = PassiveComponent("s1", LinearMovement(0.0, 1, perp_to_floor))
+    super_mirror = ActiveComponent("sm", LinearMovement(0.0, 5, perp_to_floor))
+    s2 = PassiveComponent("s2", LinearMovement(0.0, 9, perp_to_floor))
+    sample = ActiveComponent("sample", LinearMovement(0.0, 10, perp_to_floor))
+    s3 = PassiveComponent("s3", LinearMovement(0.0, 15, perp_to_floor))
+    s4 = PassiveComponent("s4", LinearMovement(0.0, 19, perp_to_floor))
+    point_det = TiltingJaws("det", LinearMovement(0.0, 20, perp_to_floor))
+    comps = [s1, super_mirror, s2, sample, s3, s4, point_det]
+
+    # BEAMLINE PARAMETERS
+    sm_enabled = ComponentEnabled("smenabled", super_mirror)
+    sm_angle = ReflectionAngle("smangle", super_mirror)
+    slit2_pos = TrackingPosition("slit2pos", s2)
+    sample_pos = TrackingPosition("samplepos", sample)
+    theta = Theta("theta", sample)
+    slit3_pos = TrackingPosition("slit3pos", s3)
+    slit4_pos = TrackingPosition("slit4pos", s4)
+    det = TrackingPosition("detpos", point_det)
+    # Initialise to avoid exceptions
+    # sm_enabled.sp_no_move = False
+    # sm_angle.sp_no_move = 0.0
+    # slit2_pos.sp_no_move = 0.0
+    # sample_pos.sp_no_move = 0.0
+    # theta.sp_no_move = 0.0
+    # slit3_pos.sp_no_move = 0.0
+    # slit4_pos.sp_no_move = 0.0
+    # det.sp_no_move = 0.0
+    params = [sm_enabled,
+              sm_angle,
+              slit2_pos,
+              sample_pos,
+              theta,
+              slit3_pos,
+              slit4_pos,
+              det]
+
+    # init beamline
+    bl = Beamline(comps, params, MODES)
+    bl.set_incoming_beam(beam_start)
+    bl.active_mode = NR_MODE
+    return bl
+
+beamline = create_beamline()
+
+pv_db = PVManager(PARAMS_FIELDS, [mode.name for mode in MODES])
+SERVER = SimpleServer()
+for pv_name in pv_db.PVDB.keys():
+    print("creating pv: " + pv_name)
+SERVER.createPV(REFLECTOMETRY_PREFIX, pv_db.PVDB)
+DRIVER = ReflectometryDriver(SERVER, beamline, pv_db)
+
+# Process CA transactions
+while True:
+    try:
+        SERVER.process(0.1)
+    except Exception as err:
+        print(err)
+        break

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -5,6 +5,7 @@ from src.beamline import Beamline, BeamlineMode
 from src.parameters import *
 from src.ChannelAccess.pv_server import ReflectometryDriver
 from src.ChannelAccess.pv_manager import PVManager
+from src.movement_strategy import LinearMovement
 
 STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["OUT", "IN"]}
 FLOAT_PV_FIELDS = {'type': 'float', 'prec': 3, 'value': 0.0}
@@ -25,19 +26,19 @@ def create_beamline():
     perp_to_floor = 90.0
 
     # COMPONENTS
-    # s1 = PassiveComponent("s1", LinearMovement(0.0, 7.3025, perp_to_beam_angle))
-    # s2 = PassiveComponent("s2", LinearMovement(0.0, 9.6885, perp_to_beam_angle))
-    # s3 = PassiveComponent("s3", LinearMovement(0.0, 10.651, perp_to_beam_angle))
-    # s4 = PassiveComponent("s4", LinearMovement(0.0, 11.983, perp_to_beam_angle))
-    # super_mirror = ActiveComponent("sm", LinearMovement(0.0, 7.7685, perp_to_beam_angle))
-    # sample = ActiveComponent("sample", LinearMovement(0.0, 10.25, perp_to_beam_angle))
+    # s1 = Component("s1", LinearMovement(0.0, 7.3025, perp_to_beam_angle))
+    # s2 = Component("s2", LinearMovement(0.0, 9.6885, perp_to_beam_angle))
+    # s3 = Component("s3", LinearMovement(0.0, 10.651, perp_to_beam_angle))
+    # s4 = Component("s4", LinearMovement(0.0, 11.983, perp_to_beam_angle))
+    # super_mirror = ReflectingComponent("sm", LinearMovement(0.0, 7.7685, perp_to_beam_angle))
+    # sample = ReflectingComponent("sample", LinearMovement(0.0, 10.25, perp_to_beam_angle))
     # point_det = TiltingJaws("pdet", LinearMovement(0.0, 12.113, perp_to_beam_angle))
-    s1 = PassiveComponent("s1", LinearMovement(0.0, 1, perp_to_floor))
-    super_mirror = ActiveComponent("sm", LinearMovement(0.0, 5, perp_to_floor))
-    s2 = PassiveComponent("s2", LinearMovement(0.0, 9, perp_to_floor))
-    sample = ActiveComponent("sample", LinearMovement(0.0, 10, perp_to_floor))
-    s3 = PassiveComponent("s3", LinearMovement(0.0, 15, perp_to_floor))
-    s4 = PassiveComponent("s4", LinearMovement(0.0, 19, perp_to_floor))
+    s1 = Component("s1", LinearMovement(0.0, 1, perp_to_floor))
+    super_mirror = ReflectingComponent("sm", LinearMovement(0.0, 5, perp_to_floor))
+    s2 = Component("s2", LinearMovement(0.0, 9, perp_to_floor))
+    sample = ReflectingComponent("sample", LinearMovement(0.0, 10, perp_to_floor))
+    s3 = Component("s3", LinearMovement(0.0, 15, perp_to_floor))
+    s4 = Component("s4", LinearMovement(0.0, 19, perp_to_floor))
     point_det = TiltingJaws("det", LinearMovement(0.0, 20, perp_to_floor))
     comps = [s1, super_mirror, s2, sample, s3, s4, point_det]
 

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -43,14 +43,14 @@ def create_beamline():
     comps = [s1, super_mirror, s2, sample, s3, s4, point_det]
 
     # BEAMLINE PARAMETERS
-    sm_enabled = ComponentEnabled("smenabled", super_mirror)
-    sm_angle = ReflectionAngle("smangle", super_mirror)
-    slit2_pos = TrackingPosition("slit2pos", s2)
-    sample_pos = TrackingPosition("samplepos", sample)
-    theta = Theta("theta", sample)
-    slit3_pos = TrackingPosition("slit3pos", s3)
-    slit4_pos = TrackingPosition("slit4pos", s4)
-    det = TrackingPosition("detpos", point_det)
+    sm_enabled = ComponentEnabled("smenabled", super_mirror, True)
+    sm_angle = ReflectionAngle("smangle", super_mirror, True)
+    slit2_pos = TrackingPosition("slit2pos", s2, True)
+    sample_pos = TrackingPosition("samplepos", sample, True)
+    theta = Theta("theta", sample, True)
+    slit3_pos = TrackingPosition("slit3pos", s3, True)
+    slit4_pos = TrackingPosition("slit4pos", s4, True)
+    det = TrackingPosition("detpos", point_det, True)
     params = [sm_enabled,
               sm_angle,
               slit2_pos,

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -19,15 +19,6 @@ PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
                  "detpos": FLOAT_PV_FIELDS,
                  }
 
-NR_INITS = {"smenabled": False, "smangle": 0.0}
-PNR_INITS = {"smenabled": True, "smangle": 0.5}
-
-NR_MODE = BeamlineMode("nr", PARAMS_FIELDS.keys(), NR_INITS)
-PNR_MODE = BeamlineMode("pnr", PARAMS_FIELDS.keys(), PNR_INITS)
-DISABLED_MODE = BeamlineMode("disabled", [])
-
-MODES = [NR_MODE, PNR_MODE, DISABLED_MODE]
-
 
 def create_beamline():
     beam_angle_natural = -45
@@ -60,15 +51,6 @@ def create_beamline():
     slit3_pos = TrackingPosition("slit3pos", s3)
     slit4_pos = TrackingPosition("slit4pos", s4)
     det = TrackingPosition("detpos", point_det)
-    # Initialise to avoid exceptions
-    # sm_enabled.sp_no_move = False
-    # sm_angle.sp_no_move = 0.0
-    # slit2_pos.sp_no_move = 0.0
-    # sample_pos.sp_no_move = 0.0
-    # theta.sp_no_move = 0.0
-    # slit3_pos.sp_no_move = 0.0
-    # slit4_pos.sp_no_move = 0.0
-    # det.sp_no_move = 0.0
     params = [sm_enabled,
               sm_angle,
               slit2_pos,
@@ -78,15 +60,24 @@ def create_beamline():
               slit4_pos,
               det]
 
+    nr_inits = {"smenabled": False, "smangle": 0.0}
+    pnr_inits = {"smenabled": True, "smangle": 0.5}
+
+    nr_mode = BeamlineMode("nr", params, nr_inits)
+    pnr_mode = BeamlineMode("pnr", [param for param in params if param.name is not "smangle"], pnr_inits)
+    disabled_mode = BeamlineMode("disabled", [])
+
+    modes = [nr_mode, pnr_mode, disabled_mode]
+
     # init beamline
-    bl = Beamline(comps, params, MODES)
+    bl = Beamline(comps, params, modes)
     bl.set_incoming_beam(beam_start)
-    bl.active_mode = NR_MODE
+    bl.active_mode = nr_mode
     return bl
 
 beamline = create_beamline()
 
-pv_db = PVManager(PARAMS_FIELDS, [mode.name for mode in MODES])
+pv_db = PVManager(PARAMS_FIELDS)
 SERVER = SimpleServer()
 for pv_name in pv_db.PVDB.keys():
     print("creating pv: " + pv_name)

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -6,7 +6,7 @@ from src.parameters import *
 from src.ChannelAccess.pv_server import ReflectometryDriver
 from src.ChannelAccess.pv_manager import PVManager
 
-STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["NO", "YES"]}
+STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["OUT", "IN"]}
 FLOAT_PV_FIELDS = {'type': 'float', 'prec': 3, 'value': 0.0}
 PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
                  "smangle": FLOAT_PV_FIELDS,
@@ -73,11 +73,11 @@ def create_beamline():
     bl = Beamline(comps, params, modes)
     bl.set_incoming_beam(beam_start)
     bl.active_mode = nr_mode
-    return bl
+    return bl, modes
 
-beamline = create_beamline()
+beamline, modes = create_beamline()
 
-pv_db = PVManager(PARAMS_FIELDS)
+pv_db = PVManager(PARAMS_FIELDS, [mode.name for mode in modes])
 SERVER = SimpleServer()
 for pv_name in pv_db.PVDB.keys():
     print("creating pv: " + pv_name)

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -75,6 +75,7 @@ def create_beamline():
     bl.active_mode = nr_mode
     return bl, modes
 
+
 beamline, modes = create_beamline()
 
 pv_db = PVManager(PARAMS_FIELDS, [mode.name for mode in modes])

--- a/sim_ioc.py
+++ b/sim_ioc.py
@@ -14,7 +14,6 @@ PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
                  "samplepos": FLOAT_PV_FIELDS,
                  "theta": FLOAT_PV_FIELDS,
                  "slit3pos": FLOAT_PV_FIELDS,
-                 "paenabled": STATUS_PV_FIELDS,
                  "slit4pos": FLOAT_PV_FIELDS,
                  "detpos": FLOAT_PV_FIELDS,
                  }

--- a/src/ChannelAccess/macros.py
+++ b/src/ChannelAccess/macros.py
@@ -1,0 +1,18 @@
+import os
+
+
+def _get_env_var(name):
+    try:
+        return os.environ[name]
+    except:
+        return ""
+
+MACROS = {
+    "$(MYPVPREFIX)": _get_env_var('MYPVPREFIX'),
+    "$(EPICS_KIT_ROOT)": _get_env_var('EPICS_KIT_ROOT'),
+    "$(ICPCONFIGROOT)": _get_env_var('ICPCONFIGROOT'),
+    "$(ICPVARDIR)": _get_env_var('ICPVARDIR')
+}
+
+REFLECTOMETRY_PREFIX = MACROS["$(MYPVPREFIX)"] + "REF:"
+PVPREFIX_MACRO = "$(MYPVPREFIX)"

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -14,7 +14,7 @@ class PVManager:
     """
     Holds reflectometry PVs and associated utilities.
     """
-    def __init__(self, params_fields):
+    def __init__(self, params_fields, modes):
         """
         The constructor.
         :param params_fields: The parameters for which to create PVs and their PV fields.
@@ -26,7 +26,8 @@ class PVManager:
                 'value': 0,
             },
             BEAMLINE_MODE: {
-                'type': 'string',
+                'type': 'enum',
+                'enums': modes
             }
         }
 

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -7,20 +7,18 @@ BEAMLINE_MOVE = "BL:MOVE"
 
 
 class PVManager:
-    PVDB = {
-        BEAMLINE_MODE: {
-            'type': 'char',
-            'count': 1000,
-            'value': [0],
-        },
-        BEAMLINE_MOVE: {
-            'type': 'int',
-            'count': 1,
-            'value': 0,
-        },
-    }
+    def __init__(self, params_fields, modes):
+        self.PVDB = {
+            BEAMLINE_MOVE: {
+                'type': 'int',
+                'count': 1,
+                'value': 0,
+            },
+            BEAMLINE_MODE: {
+                'type': 'string',
+            }
+        }
 
-    def __init__(self, params_fields):
         self._pv_lookup = {}
         for param, fields in params_fields.iteritems():
             self._add_parameter_pvs(param, **fields)
@@ -38,9 +36,9 @@ class PVManager:
             self.PVDB[prepended_alias] = fields
             self.PVDB[prepended_alias + ":SP"] = fields
             self.PVDB[prepended_alias + ":SP:RBV"] = fields
-            self.PVDB[prepended_alias + ":MOVE"] = {'type': 'char',
-                                                    'count': 100,
-                                                    'value': [0],
+            self.PVDB[prepended_alias + ":MOVE"] = {'type': 'int',
+                                                    'count': 1,
+                                                    'value': 0,
                                                     }
             self._pv_lookup[param_alias] = param_name
         except Exception as err:

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -86,7 +86,7 @@ class PVManager:
         :return: The parameter associated to the PV
         """
         try:
-            param_alias = pv.split(":")[-2]
+            param_alias = pv.split(":")[1]
             return self._pv_lookup[param_alias]
         except KeyError:
             pass  # TODO no such pv ?

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -4,6 +4,10 @@ import re
 PARAM_PREFIX = "PARAM:"
 BEAMLINE_MODE = "BL:MODE"
 BEAMLINE_MOVE = "BL:MOVE"
+SP_SUFFIX = ":SP"
+SP_RBV_SUFFIX = ":SP:RBV"
+MOVE_SUFFIX = ":MOVE"
+SET_AND_MOVE_SUFFIX = ":SETANDMOVE"
 
 
 class PVManager:
@@ -34,9 +38,10 @@ class PVManager:
             param_alias = self.create_pv_alias(param_name, "PARAM")
             prepended_alias = PARAM_PREFIX + param_alias
             self.PVDB[prepended_alias] = fields
-            self.PVDB[prepended_alias + ":SP"] = fields
-            self.PVDB[prepended_alias + ":SP:RBV"] = fields
-            self.PVDB[prepended_alias + ":MOVE"] = {'type': 'int',
+            self.PVDB[prepended_alias + SP_SUFFIX] = fields
+            self.PVDB[prepended_alias + SP_RBV_SUFFIX] = fields
+            self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX] = fields
+            self.PVDB[prepended_alias + MOVE_SUFFIX] = {'type': 'int',
                                                     'count': 1,
                                                     'value': 0,
                                                     }

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -1,0 +1,94 @@
+import re
+
+
+PARAM_PREFIX = "PARAM:"
+BEAMLINE_MODE = "BL:MODE"
+BEAMLINE_MOVE = "BL:MOVE"
+
+
+class PVManager:
+    PVDB = {
+        BEAMLINE_MODE: {
+            'type': 'char',
+            'count': 1000,
+            'value': [0],
+        },
+        BEAMLINE_MOVE: {
+            'type': 'int',
+            'count': 1,
+            'value': 0,
+        },
+    }
+
+    def __init__(self, params_fields):
+        self._pv_lookup = {}
+        for param, fields in params_fields.iteritems():
+            self._add_parameter_pvs(param, **fields)
+
+    def _add_parameter_pvs(self, param_name, **fields):
+        """
+        Adds all PVs needed for one beamline parameter to the PV database.
+
+        :param param_name: The name of the beamline parameter
+        :param fields: The fields of the parameter PV (e.g type)
+        """
+        try:
+            param_alias = self.create_pv_alias(param_name, "PARAM")
+            prepended_alias = PARAM_PREFIX + param_alias
+            self.PVDB[prepended_alias] = fields
+            self.PVDB[prepended_alias + ":SP"] = fields
+            self.PVDB[prepended_alias + ":SP:RBV"] = fields
+            self.PVDB[prepended_alias + ":MOVE"] = {'type': 'char',
+                                                    'count': 100,
+                                                    'value': [0],
+                                                    }
+            self._pv_lookup[param_alias] = param_name
+        except Exception as err:
+            pass  # TODO do something sensible
+
+    # TODO get this from blockserver utilities instead
+    def create_pv_alias(self, name, default_pv, limit=6):
+        """Uses the given name as a basis for a valid PV limited to a number of characters.
+
+        Args:
+            name (string): The basis for the PV
+            default_pv (string): Basis for the PV if name is unreasonable, must be a valid PV name
+            limit (integer): Character limit for the PV
+
+        Returns:
+            string : A valid PV
+        """
+        pv_text = name.upper().replace(" ", "_")
+        pv_text = re.sub(r'\W', '', pv_text)
+        # Check some edge cases of unreasonable names
+        if re.search(r"[^0-9_]", pv_text) is None or pv_text == '':
+            pv_text = default_pv
+
+        # Ensure PVs aren't too long for the 60 character limit
+        if pv_text > limit:
+            pv_text = pv_text[0:limit]
+
+        # Make sure PVs are unique
+        i = 1
+        pv = pv_text
+
+        # Append a number if the PV already exists
+        while pv in self.PVDB.keys():
+            if len(pv) > limit - 2:
+                pv = pv[0:limit - 2]
+            pv += format(i, '02d')
+            i += 1
+
+        return pv
+
+    def get_param_name_from_pv(self, pv):
+        """
+        Extracts the name of a beamline parameter based on its PV address.
+        :param pv: The PV address
+        :return: The parameter associated to the PV
+        """
+        try:
+            param_alias = pv.split(":")[-2]
+            return self._pv_lookup[param_alias]
+        except KeyError:
+            pass  # TODO no such pv ?

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -7,6 +7,7 @@ BEAMLINE_MOVE = "BL:MOVE"
 SP_SUFFIX = ":SP"
 SP_RBV_SUFFIX = ":SP:RBV"
 MOVE_SUFFIX = ":MOVE"
+CHANGED_SUFFIX = ":CHANGED"
 SET_AND_MOVE_SUFFIX = ":SETANDMOVE"
 
 
@@ -49,10 +50,12 @@ class PVManager:
             self.PVDB[prepended_alias + SP_SUFFIX] = fields
             self.PVDB[prepended_alias + SP_RBV_SUFFIX] = fields
             self.PVDB[prepended_alias + SET_AND_MOVE_SUFFIX] = fields
+            self.PVDB[prepended_alias + CHANGED_SUFFIX] = {'type': 'enum',
+                                                           'enums': ["NO", "YES"]}
             self.PVDB[prepended_alias + MOVE_SUFFIX] = {'type': 'int',
-                                                    'count': 1,
-                                                    'value': 0,
-                                                    }
+                                                        'count': 1,
+                                                        'value': 0,
+                                                        }
             self._pv_lookup[param_alias] = param_name
         except Exception as err:
             print("Error adding parameter PV: " + err.message)
@@ -103,3 +106,9 @@ class PVManager:
             return self._pv_lookup[param_alias]
         except KeyError:
             print("Error: Could not find beamline parameter for alias " + param_alias)
+
+    def parameter_pvs(self):
+        """
+        :return: The list of PVs of all beamline parameters.
+        """
+        return [PARAM_PREFIX + pv_alias for pv_alias in self._pv_lookup.keys()]

--- a/src/ChannelAccess/pv_manager.py
+++ b/src/ChannelAccess/pv_manager.py
@@ -11,7 +11,14 @@ SET_AND_MOVE_SUFFIX = ":SETANDMOVE"
 
 
 class PVManager:
-    def __init__(self, params_fields, modes):
+    """
+    Holds reflectometry PVs and associated utilities.
+    """
+    def __init__(self, params_fields):
+        """
+        The constructor.
+        :param params_fields: The parameters for which to create PVs and their PV fields.
+        """
         self.PVDB = {
             BEAMLINE_MOVE: {
                 'type': 'int',
@@ -32,7 +39,7 @@ class PVManager:
         Adds all PVs needed for one beamline parameter to the PV database.
 
         :param param_name: The name of the beamline parameter
-        :param fields: The fields of the parameter PV (e.g type)
+        :param fields: The fields of the parameter PV
         """
         try:
             param_alias = self.create_pv_alias(param_name, "PARAM")
@@ -47,7 +54,7 @@ class PVManager:
                                                     }
             self._pv_lookup[param_alias] = param_name
         except Exception as err:
-            pass  # TODO do something sensible
+            print("Error adding parameter PV: " + err.message)
 
     # TODO get this from blockserver utilities instead
     def create_pv_alias(self, name, default_pv, limit=6):
@@ -90,8 +97,8 @@ class PVManager:
         :param pv: The PV address
         :return: The parameter associated to the PV
         """
+        param_alias = pv.split(":")[1]
         try:
-            param_alias = pv.split(":")[1]
             return self._pv_lookup[param_alias]
         except KeyError:
-            pass  # TODO no such pv ?
+            print("Error: Could not find beamline parameter for alias " + param_alias)

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -60,7 +60,7 @@ class ReflectometryDriver(Driver):
             self._beamline.move = 1
         elif reason == BEAMLINE_MODE:
             try:
-                mode_to_set = self._beamline.mode(value.upper())
+                mode_to_set = self._beamline.get_mode_by_index(value)
                 self._beamline.active_mode = mode_to_set
             except KeyError:
                 print("Invalid value entered for mode.")  # TODO print list of options

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -35,7 +35,7 @@ class ReflectometryDriver(Driver):
         if reason.startswith(PARAM_PREFIX):
             param_name = self._pvdb.get_param_name_from_pv(reason)
             param = self._beamline.parameter(param_name)
-            if reason.endswith("SP"):
+            if reason.endswith(SP_SUFFIX):
                 return param.sp
             else:
                 return param.sp_rbv
@@ -53,10 +53,12 @@ class ReflectometryDriver(Driver):
         if reason.startswith(PARAM_PREFIX):
             param_name = self._pvdb.get_param_name_from_pv(reason)
             param = self._beamline.parameter(param_name)
-            if reason.endswith("MOVE"):
-                self._beamline.update_beamline_parameters(param)
-            elif reason.endswith("SP"):
+            if reason.endswith(MOVE_SUFFIX):
+                param.move = 1
+            elif reason.endswith(SP_SUFFIX):
                 param.sp_no_move = value
+            elif reason.endswith(SET_AND_MOVE_SUFFIX):
+                param.sp = value
         elif reason == BEAMLINE_MOVE:
             self._beamline.move = 1
         elif reason == BEAMLINE_MODE:

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -1,0 +1,65 @@
+from pcaspy import Driver
+from threading import RLock
+from pv_manager import *
+
+
+class ReflectometryDriver(Driver):
+    """
+    The driver which provides an interface for the reflectometry server to channel access by creating PVs and processing
+    incoming CA get and put requests.
+    """
+    def __init__(self, server, beamline, pv_manager):
+        """
+        The Constructor.
+        :param server: The PCASpy server.
+        :param beamline: The beamline configuration.
+        :param pv_manager: The manager mapping PVs to objects in the beamline.
+        """
+        super(ReflectometryDriver, self).__init__()
+        # Threading stuff TODO needed?
+        self.monitor_lock = RLock()
+        self.write_lock = RLock()
+        self.write_queue = list()
+
+        # self._beamline = BeamlineConfigReader.read("some.file")  # TODO read from config file
+        self._beamline = beamline
+        self._ca_server = server
+        self._pvdb = pv_manager
+
+    def read(self, reason):
+        """
+        Processes an incoming caget request.
+        :param reason: The PV that is being read.
+        :return: The value associated to this PV
+        """
+        if reason.endswith("BL:MODE"):
+            return self._beamline.mode
+        elif reason.endswith("SP"):
+            param_name = self._pvdb.get_param_name_from_pv(reason)
+            return self._beamline.parameter(param_name).sp_rbv
+        else:
+            return self.getParam(reason)
+
+    def write(self, reason, value):
+        """
+        Process an incoming caput request.
+        :param reason: The PV that is being written to.
+        :param value: The value being written to the PV
+        """
+        if reason.startswith(PARAM_PREFIX):
+            param_name = self._pvdb.get_param_name_from_pv(reason)
+            param = self._beamline.parameter(param_name)
+            if reason.endswith("MOVE"):
+                self._beamline.update_beamline_parameters(param)
+            elif reason.endswith("SP"):
+                param.sp = value
+        elif reason == BEAMLINE_MOVE:
+            self._beamline.move = 1
+        elif reason == BEAMLINE_MODE:
+            # mode_to_set =
+            self._beamline.mode = value
+        else:
+            # TODO stop, rbv
+            pass
+        self.setParam(reason, value)
+

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -32,11 +32,15 @@ class ReflectometryDriver(Driver):
         :param reason: The PV that is being read.
         :return: The value associated to this PV
         """
-        if reason.endswith("BL:MODE"):
-            return self._beamline.active_mode.name
-        elif reason.endswith("SP"):
+        if reason.startswith(PARAM_PREFIX):
             param_name = self._pvdb.get_param_name_from_pv(reason)
-            return self._beamline.parameter(param_name).sp_rbv
+            param = self._beamline.parameter(param_name)
+            if reason.endswith("SP"):
+                return param.sp
+            else:
+                return param.sp_rbv
+        elif reason.endswith("BL:MODE"):
+            return self._beamline.active_mode.name
         else:
             return self.getParam(reason)
 

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -33,7 +33,7 @@ class ReflectometryDriver(Driver):
         :return: The value associated to this PV
         """
         if reason.endswith("BL:MODE"):
-            return self._beamline.mode
+            return self._beamline.active_mode.name
         elif reason.endswith("SP"):
             param_name = self._pvdb.get_param_name_from_pv(reason)
             return self._beamline.parameter(param_name).sp_rbv
@@ -56,8 +56,8 @@ class ReflectometryDriver(Driver):
         elif reason == BEAMLINE_MOVE:
             self._beamline.move = 1
         elif reason == BEAMLINE_MODE:
-            # mode_to_set =
-            self._beamline.mode = value
+            mode_to_set = self._beamline.mode(value)
+            self._beamline.active_mode = mode_to_set
         else:
             # TODO stop, rbv
             pass

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -16,10 +16,6 @@ class ReflectometryDriver(Driver):
         :param pv_manager: The manager mapping PVs to objects in the beamline.
         """
         super(ReflectometryDriver, self).__init__()
-        # Threading stuff TODO needed?
-        self.monitor_lock = RLock()
-        self.write_lock = RLock()
-        self.write_queue = list()
 
         self._beamline = beamline
         self._ca_server = server

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -60,7 +60,7 @@ class ReflectometryDriver(Driver):
         elif reason == BEAMLINE_MOVE:
             self._beamline.move = 1
         elif reason == BEAMLINE_MODE:
-            mode_to_set = self._beamline.mode(value)
+            mode_to_set = self._beamline.mode(value.upper())
             self._beamline.active_mode = mode_to_set
         else:
             # TODO stop, rbv

--- a/src/ChannelAccess/pv_server.py
+++ b/src/ChannelAccess/pv_server.py
@@ -70,4 +70,3 @@ class ReflectometryDriver(Driver):
                 print("Invalid value entered for mode.")  # TODO print list of options
 
         self.setParam(reason, value)
-

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -80,7 +80,7 @@ class Beamline(object):
         """
         self._components = components
         self._beamline_parameters = OrderedDict()
-        self._modes = {}
+        self._modes = OrderedDict()
         for mode in modes:
             self._modes[mode.name] = mode
         for beamline_parameter in beamline_parameters:
@@ -183,6 +183,10 @@ class Beamline(object):
             src.parameters.BeamlineParameter: the beamline parameter with the given key
         """
         return self._beamline_parameters[key]
+
+    def get_mode_by_index(self, index):
+        key = self._modes.keys()[index]
+        return self.mode(key)
 
     def mode(self, key):
         """

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -18,7 +18,7 @@ class BeamlineMode(object):
                 which should be automatically moved to whenever a preceding parameter is changed
             sp_inits: The initial beamline parameter values that should be set when switching to this mode
         """
-        self.name = name
+        self.name = name.upper()
         self._beamline_parameters_to_calculate = beamline_parameters_to_calculate
         if sp_inits is None:
             self._sp_inits = {}

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -86,6 +86,10 @@ class Beamline(object):
         self.incoming_beam = None
         self._mode = None
 
+    @property
+    def mode(self):
+        return self._mode
+
     def _mode(self, mode):
         self._mode = mode
         self.init_setpoints()

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -167,11 +167,12 @@ class Beamline(object):
 
         """
         if source is None or self._active_mode.has_beamline_parameter(source):
+            parameters = self._beamline_parameters.values()
+            parameters_in_mode = self._active_mode.get_parameters_in_mode(parameters, source)
 
-            parameters_in_mode = self._active_mode.get_parameters_in_mode(self._beamline_parameters.values(), source)
-
-            for beamline_parameter in parameters_in_mode:
-                beamline_parameter.move_no_callback()
+            for beamline_parameter in parameters:
+                if beamline_parameter in parameters_in_mode or beamline_parameter.sp_changed:
+                    beamline_parameter.move_no_callback()
 
     def parameter(self, key):
         """

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -14,7 +14,7 @@ class BeamlineMode(object):
         Initialize.
         Args:
             name (str): name of the beam line mode
-            beamline_parameters_to_calculate (list[src.parameters.BeamlineParameter]): Beamline parameters in this mode
+            beamline_parameters_to_calculate (list[string]): Beamline parameters in this mode
                 which should be automatically moved to whenever a preceding parameter is changed
             sp_inits: The initial beamline parameter values that should be set when switching to this mode
         """

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -9,9 +9,9 @@ class BeamlineParameter(object):
     value that is set.
     """
 
-    def __init__(self, name):
-        self._set_point = None
-        self._set_point_rbv = None
+    def __init__(self, name, init=None):
+        self._set_point = init
+        self._set_point_rbv = init
         self._sp_is_changed = False
         self._name = name
         self.after_move_listener = lambda x: None
@@ -111,14 +111,14 @@ class ReflectionAngle(BeamlineParameter):
     Angle is measure with +ve in the anti-clockwise direction)
     """
 
-    def __init__(self, name, reflection_component):
+    def __init__(self, name, reflection_component, init=0.0):
         """
         Initializer.
         Args:
             name (str): Name of the reflection angle
             reflection_component (src.components.ActiveComponent): the active component at the reflection point
         """
-        super(ReflectionAngle, self).__init__(name, )
+        super(ReflectionAngle, self).__init__(name, init)
         self._reflection_component = reflection_component
 
     def _move_component(self):
@@ -131,14 +131,14 @@ class Theta(ReflectionAngle):
     Angle is measure with +ve in the anti-clockwise direction (opposite of room coordinates)
     """
 
-    def __init__(self, name, ideal_sample_point):
+    def __init__(self, name, ideal_sample_point, init = 0.0):
         """
         Initializer.
         Args:
             name (str): name of theta
             ideal_sample_point (src.components.ActiveComponent): the ideal sample point active component
         """
-        super(Theta, self).__init__(name, ideal_sample_point)
+        super(Theta, self).__init__(name, ideal_sample_point, init)
 
 
 class TrackingPosition(BeamlineParameter):
@@ -146,14 +146,14 @@ class TrackingPosition(BeamlineParameter):
     Component which tracks the position of the beam with a single degree of freedom. E.g. slit set on a height stage
     """
 
-    def __init__(self, name, component):
+    def __init__(self, name, component, init=0.0):
         """
 
         Args:
             name: Name of the variable
             component (src.components.PassiveComponent): component that the tracking is based on
         """
-        super(TrackingPosition, self).__init__(name)
+        super(TrackingPosition, self).__init__(name, init)
         self._component = component
 
     def _move_component(self):
@@ -165,14 +165,14 @@ class ComponentEnabled(BeamlineParameter):
     Parameter which sets whether a given device is enabled (i.e. parked in beam) on the beamline.
     """
 
-    def __init__(self, name, component):
+    def __init__(self, name, component, init=False):
         """
         Initializer.
         Args:
             name (str): Name of the enabled parameter
             component (src.components.PassiveComponent): the component to be enabled or disabled
         """
-        super(ComponentEnabled, self).__init__(name, )
+        super(ComponentEnabled, self).__init__(name, init)
         self._component = component
 
     def _move_component(self):

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -43,7 +43,7 @@ class BeamlineParameter(object):
         Args:
             set_point: the set point
         """
-        self._set_point = float(set_point)
+        self._set_point = set_point
         self._sp_is_changed = True
 
     @property

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -9,9 +9,12 @@ class BeamlineParameter(object):
     value that is set.
     """
 
-    def __init__(self, name, init=None):
-        self._set_point = init
-        self._set_point_rbv = init
+    def __init__(self, name, sim=False, init=None):
+        if sim:
+            self._set_point = init
+            self._set_point_rbv = init
+        else:
+            self._set_point = None
         self._sp_is_changed = False
         self._name = name
         self.after_move_listener = lambda x: None
@@ -111,14 +114,14 @@ class ReflectionAngle(BeamlineParameter):
     Angle is measure with +ve in the anti-clockwise direction)
     """
 
-    def __init__(self, name, reflection_component, init=0.0):
+    def __init__(self, name, reflection_component, sim=False, init=0):
         """
         Initializer.
         Args:
             name (str): Name of the reflection angle
             reflection_component (src.components.ActiveComponent): the active component at the reflection point
         """
-        super(ReflectionAngle, self).__init__(name, init)
+        super(ReflectionAngle, self).__init__(name, sim, init)
         self._reflection_component = reflection_component
 
     def _move_component(self):
@@ -131,14 +134,14 @@ class Theta(ReflectionAngle):
     Angle is measure with +ve in the anti-clockwise direction (opposite of room coordinates)
     """
 
-    def __init__(self, name, ideal_sample_point, init = 0.0):
+    def __init__(self, name, ideal_sample_point, sim=False, init=0):
         """
         Initializer.
         Args:
             name (str): name of theta
             ideal_sample_point (src.components.ActiveComponent): the ideal sample point active component
         """
-        super(Theta, self).__init__(name, ideal_sample_point, init)
+        super(Theta, self).__init__(name, ideal_sample_point, sim, init)
 
 
 class TrackingPosition(BeamlineParameter):
@@ -146,14 +149,14 @@ class TrackingPosition(BeamlineParameter):
     Component which tracks the position of the beam with a single degree of freedom. E.g. slit set on a height stage
     """
 
-    def __init__(self, name, component, init=0.0):
+    def __init__(self, name, component, sim=False, init=0):
         """
 
         Args:
             name: Name of the variable
             component (src.components.PassiveComponent): component that the tracking is based on
         """
-        super(TrackingPosition, self).__init__(name, init)
+        super(TrackingPosition, self).__init__(name, sim, init)
         self._component = component
 
     def _move_component(self):
@@ -165,14 +168,14 @@ class ComponentEnabled(BeamlineParameter):
     Parameter which sets whether a given device is enabled (i.e. parked in beam) on the beamline.
     """
 
-    def __init__(self, name, component, init=False):
+    def __init__(self, name, component, sim=False, init=False):
         """
         Initializer.
         Args:
             name (str): Name of the enabled parameter
             component (src.components.PassiveComponent): the component to be enabled or disabled
         """
-        super(ComponentEnabled, self).__init__(name, init)
+        super(ComponentEnabled, self).__init__(name, sim, init)
         self._component = component
 
     def _move_component(self):

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -1,6 +1,18 @@
 from src.beamline import BeamlineMode, Beamline
 from src.parameters import BeamlineParameter
 
+STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["NO", "YES"]}
+FLOAT_PV_FIELDS = {'type': 'float', 'prec': 3, 'value': 0.0}
+PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
+                 "smangle": FLOAT_PV_FIELDS,
+                 "slit2pos": FLOAT_PV_FIELDS,
+                 "samplepos": FLOAT_PV_FIELDS,
+                 "theta": FLOAT_PV_FIELDS,
+                 "slit3pos": FLOAT_PV_FIELDS,
+                 "paenabled": STATUS_PV_FIELDS,
+                 "slit4pos": FLOAT_PV_FIELDS,
+                 "detpos": FLOAT_PV_FIELDS,
+                 }
 
 class EmptyBeamlineParameter(BeamlineParameter):
     """

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -1,28 +1,6 @@
 from src.beamline import BeamlineMode, Beamline
 from src.parameters import BeamlineParameter
 
-STATUS_PV_FIELDS = {'type': 'enum', 'enums': ["NO", "YES"]}
-FLOAT_PV_FIELDS = {'type': 'float', 'prec': 3, 'value': 0.0}
-PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
-                 "smangle": FLOAT_PV_FIELDS,
-                 "slit2pos": FLOAT_PV_FIELDS,
-                 "samplepos": FLOAT_PV_FIELDS,
-                 "theta": FLOAT_PV_FIELDS,
-                 "slit3pos": FLOAT_PV_FIELDS,
-                 "paenabled": STATUS_PV_FIELDS,
-                 "slit4pos": FLOAT_PV_FIELDS,
-                 "detpos": FLOAT_PV_FIELDS,
-                 }
-
-NR_INITS = {"smenabled": False, "smangle": 0.0}
-PNR_INITS = {"smenabled": True, "smangle": 0.5}
-
-NR_MODE = BeamlineMode("nr", PARAMS_FIELDS.keys(), NR_INITS)
-PNR_MODE = BeamlineMode("pnr", PARAMS_FIELDS.keys(), PNR_INITS)
-DISABLED_MODE = BeamlineMode("disabled", [])
-
-MODES = [NR_MODE, PNR_MODE, DISABLED_MODE]
-
 
 class EmptyBeamlineParameter(BeamlineParameter):
     """

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -14,6 +14,16 @@ PARAMS_FIELDS = {"smenabled": STATUS_PV_FIELDS,
                  "detpos": FLOAT_PV_FIELDS,
                  }
 
+NR_INITS = {"smenabled": False, "smangle": 0.0}
+PNR_INITS = {"smenabled": True, "smangle": 0.5}
+
+NR_MODE = BeamlineMode("nr", PARAMS_FIELDS.keys(), NR_INITS)
+PNR_MODE = BeamlineMode("pnr", PARAMS_FIELDS.keys(), PNR_INITS)
+DISABLED_MODE = BeamlineMode("disabled", [])
+
+MODES = [NR_MODE, PNR_MODE, DISABLED_MODE]
+
+
 class EmptyBeamlineParameter(BeamlineParameter):
     """
     A Bemline Parameter Stub. Counts the number of time it is asked to move
@@ -45,6 +55,6 @@ class DataMother(object):
         two = EmptyBeamlineParameter("two")
         three = EmptyBeamlineParameter("three")
         beamline_parameters = [one, two, three]
-        beamline = Beamline([], beamline_parameters)
-        beamline.mode = BeamlineMode("all", [beamline_parameter.name for beamline_parameter in beamline_parameters])
+        beamline = Beamline([], beamline_parameters, [])
+        beamline.active_mode = BeamlineMode("all", [beamline_parameter.name for beamline_parameter in beamline_parameters])
         return beamline_parameters, beamline

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -33,6 +33,7 @@ class DataMother(object):
         two = EmptyBeamlineParameter("two")
         three = EmptyBeamlineParameter("three")
         beamline_parameters = [one, two, three]
-        beamline = Beamline([], beamline_parameters, [])
-        beamline.active_mode = BeamlineMode("all", [beamline_parameter.name for beamline_parameter in beamline_parameters])
+        mode = BeamlineMode("all", [beamline_parameter.name for beamline_parameter in beamline_parameters])
+        beamline = Beamline([], beamline_parameters, [mode])
+        beamline.active_mode = mode
         return beamline_parameters, beamline

--- a/tests/test_actual_positions.py
+++ b/tests/test_actual_positions.py
@@ -32,13 +32,13 @@ class TestComponentBeamline(unittest.TestCase):
         smangle.sp = 0
         self.beamline = Beamline(
             [s0, s1, frame_overlap_mirror, self.polarising_mirror, s2, self.ideal_sample_point, s3, analyser, s4, detector],
-            [smangle, theta])
+            [smangle, theta], [])
         self.beamline.set_incoming_beam(beam_start)
         self.nr_mode = BeamlineMode("NR Mode", [theta.name])
         self.polarised_mode = BeamlineMode("NR Mode", [smangle.name, theta.name])
 
     def test_GIVEN_beam_line_contains_multiple_component_WHEN_set_theta_THEN_angle_between_incoming_and_outgoing_beam_is_correct(self):
-        self.beamline.mode = self.nr_mode
+        self.beamline.active_mode = self.nr_mode
 
         theta_set = 10.0
         self.beamline.parameter("theta").sp_move = theta_set
@@ -47,7 +47,7 @@ class TestComponentBeamline(unittest.TestCase):
         assert_that(reflection_angle, is_(theta_set * 2.0))
 
     def test_GIVEN_beam_line_contains_active_super_mirror_WHEN_set_theta_THEN_angle_between_incoming_and_outgoing_beam_is_correct(self):
-        self.beamline.mode = self.polarised_mode
+        self.beamline.active_mode = self.polarised_mode
         theta_set = 10.0
         self.polarising_mirror.enabled = True
         self.beamline.parameter("smangle").sp_move = 10
@@ -58,7 +58,7 @@ class TestComponentBeamline(unittest.TestCase):
         assert_that(reflection_angle, is_(theta_set * 2.0))
 
     def test_GIVEN_beam_line_contains_active_super_mirror_WHEN_angle_set_THEN_angle_between_incoming_and_outgoing_beam_is_correct(self):
-        self.beamline.mode = self.polarised_mode
+        self.beamline.active_mode = self.polarised_mode
         theta_set = 10.0
         self.beamline.parameter("theta").sp_move = theta_set
         self.polarising_mirror.enabled = True

--- a/tests/test_beamline.py
+++ b/tests/test_beamline.py
@@ -15,14 +15,14 @@ class TestComponentBeamline(unittest.TestCase):
         mirror = ActiveComponent("mirror", movement_strategy=LinearMovement(0, mirror_position, 90))
         mirror.angle = initial_mirror_angle
         jaws3 = PassiveComponent("jaws3", movement_strategy=LinearMovement(0, 20, 90))
-        beamline = Beamline([jaws, mirror, jaws3], {})
+        beamline = Beamline([jaws, mirror, jaws3], {}, [])
         beamline.set_incoming_beam(beam_start)
         return beamline, mirror
 
     def test_GIVEN_beam_line_contains_one_passive_component_WHEN_beam_set_THEN_component_has_beam_out_same_as_beam_in(self):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         jaws = PassiveComponent("jaws", movement_strategy=LinearMovement(0, 2, 90))
-        beamline = Beamline([jaws], {})
+        beamline = Beamline([jaws], {}, [])
         beamline.set_incoming_beam(beam_start)
 
         result = beamline[0].get_outgoing_beam()

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -141,8 +141,8 @@ class TestBeamlineModes(unittest.TestCase):
             TrackingPosition("detectorheight", detector)]
                       #parameters["detectorAngle": TrackingAngle(detector)
         beam = PositionAndAngle(0, 0, -45)
-        beamline = Beamline(components, parameters)
-        beamline.mode = DataMother.BEAMLINE_MODE_NEUTRON_REFLECTION
+        beamline = Beamline(components, parameters, [])
+        beamline.active_mode = DataMother.BEAMLINE_MODE_NEUTRON_REFLECTION
         beamline.parameter("theta").sp = 45
         beamline.parameter("height").sp = 0
         beamline.parameter("slit2height").sp = 0
@@ -160,12 +160,12 @@ class TestBeamlineModes(unittest.TestCase):
         ideal_sample_point = ActiveComponent("ideal_sample_point", LinearMovement(y_position=0, z_position=20, angle=90))
         theta = Theta("theta", ideal_sample_point)
         beamline_mode = BeamlineMode("mode name", [theta.name])
-        beamline = Beamline([ideal_sample_point], [theta])
+        beamline = Beamline([ideal_sample_point], [theta], [])
         beam = PositionAndAngle(0, 0, 0)
 
         theta.sp = angle_to_set
         beamline.set_incoming_beam(beam)
-        beamline.mode = beamline_mode
+        beamline.active_mode = beamline_mode
         beamline.move = 1
 
         assert_that(ideal_sample_point.angle, is_(angle_to_set))
@@ -176,12 +176,12 @@ class TestBeamlineModes(unittest.TestCase):
         theta = Theta("theta", ideal_sample_point)
         beamline_mode = BeamlineMode("mode name", [])
         ideal_sample_point.angle = 0
-        beamline = Beamline([ideal_sample_point], [theta])
+        beamline = Beamline([ideal_sample_point], [theta], [])
         beam = PositionAndAngle(0, 0, 0)
 
         theta.sp = angle_to_set
         beamline.set_incoming_beam(beam)
-        beamline.mode = beamline_mode
+        beamline.active_mode = beamline_mode
         beamline.move = 1
 
         assert_that(ideal_sample_point.angle, is_(0))
@@ -194,12 +194,12 @@ class TestBeamlineModes(unittest.TestCase):
         smangle = ReflectionAngle("smangle", super_mirror)
 
         beamline_mode = BeamlineMode("mode name", [theta.name, smangle.name])
-        beamline = Beamline([super_mirror, ideal_sample_point], [smangle, theta])
+        beamline = Beamline([super_mirror, ideal_sample_point], [smangle, theta], [])
         beam = PositionAndAngle(0, 0, 0)
         theta.sp = angle_to_set
         smangle.sp = 0
         beamline.set_incoming_beam(beam)
-        beamline.mode = beamline_mode
+        beamline.active_mode = beamline_mode
         beamline.move = 1
 
         smangle_to_set = -10
@@ -216,9 +216,9 @@ class TestBeamlineModes(unittest.TestCase):
         smangle.sp = sm_angle
         sp_inits = {smangle.name: sm_angle_to_set}
         beamline_mode = BeamlineMode("mode name", [smangle.name], sp_inits)
-        beamline = Beamline([super_mirror], [smangle])
+        beamline = Beamline([super_mirror], [smangle], [])
 
-        beamline.mode = beamline_mode
+        beamline.active_mode = beamline_mode
 
         assert_that(smangle.sp_rbv, is_(sm_angle_to_set))
         assert_that(smangle.sp_changed, is_(True))
@@ -232,10 +232,10 @@ class TestBeamlineModes(unittest.TestCase):
         smangle.sp = sm_angle
         sp_inits = {"nonsense name": sm_angle}
         beamline_mode = BeamlineMode("mode name", [smangle.name], sp_inits)
-        beamline = Beamline([super_mirror], [smangle])
+        beamline = Beamline([super_mirror], [smangle], [])
 
         with self.assertRaises(KeyError):
-            beamline.mode = beamline_mode
+            beamline.active_mode = beamline_mode
 
 
 class TestBeamlineOnMove(unittest.TestCase):
@@ -244,7 +244,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         one = EmptyBeamlineParameter("same")
         two = EmptyBeamlineParameter("same")
 
-        assert_that(calling(Beamline).with_args([], [one, two]), raises(ValueError))
+        assert_that(calling(Beamline).with_args([], [one, two], []), raises(ValueError))
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_1st_THEN_all_move(self):
         beamline_parameters, _ = DataMother.beamline_with_3_empty_patameters()
@@ -272,7 +272,7 @@ class TestBeamlineOnMove(unittest.TestCase):
 
     def test_GIVEN_three_beamline_parameters_and_1_and_3_in_mode_WHEN_move_1st_THEN_parameters_in_the_mode_move(self):
         beamline_parameters, beamline = DataMother.beamline_with_3_empty_patameters()
-        beamline.mode = BeamlineMode("all", [beamline_parameters[0].name, beamline_parameters[2].name])
+        beamline.active_mode = BeamlineMode("all", [beamline_parameters[0].name, beamline_parameters[2].name])
 
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
@@ -281,7 +281,7 @@ class TestBeamlineOnMove(unittest.TestCase):
 
     def test_GIVEN_three_beamline_parameters_and_3_in_mode_WHEN_move_1st_THEN_only_2nd_parameter_moved(self):
         beamline_parameters, beamline = DataMother.beamline_with_3_empty_patameters()
-        beamline.mode = BeamlineMode("all", [beamline_parameters[2].name])
+        beamline.active_mode = BeamlineMode("all", [beamline_parameters[2].name])
 
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -185,22 +185,6 @@ class TestBeamlineModes(unittest.TestCase):
 
         assert_that(ideal_sample_point.angle, is_(angle_to_set))
 
-    def test_GIVEN_a_mode_without_the_beamline_parameter_in_WHEN_move_THEN_beamline_parameter_is_not_calculated_on_move(self):
-        angle_to_set = 45.0
-        ideal_sample_point = ActiveComponent("ideal_sample_point", LinearMovement(y_position=0, z_position=20, angle=90))
-        theta = Theta("theta", ideal_sample_point)
-        beamline_mode = BeamlineMode("mode name", [])
-        ideal_sample_point.angle = 0
-        beamline = Beamline([ideal_sample_point], [theta], [])
-        beam = PositionAndAngle(0, 0, 0)
-
-        theta.sp_no_move = angle_to_set
-        beamline.set_incoming_beam(beam)
-        beamline.active_mode = beamline_mode
-        beamline.move = 1
-
-        assert_that(ideal_sample_point.angle, is_(0))
-
     def test_GIVEN_a_mode_with_a_two_beamline_parameter_in_WHEN_move_first_THEN_second_beamline_parameter_is_calculated_and_moved_to(self):
         angle_to_set = 45.0
         ideal_sample_point = ActiveComponent("ideal_sample_point", LinearMovement(y_position=0, z_position=20, angle=90))
@@ -256,7 +240,7 @@ class TestBeamlineModes(unittest.TestCase):
     def test_GIVEN_parameter_not_in_mode_and_not_changed_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
         initial_s2_height = 0.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)
@@ -274,7 +258,7 @@ class TestBeamlineModes(unittest.TestCase):
     def test_GIVEN_parameter_not_in_mode_and_not_changed_and_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
         initial_s2_height = 0.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)
@@ -293,7 +277,7 @@ class TestBeamlineModes(unittest.TestCase):
     def test_GIVEN_parameter_in_mode_and_not_changed_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
         initial_s2_height = 0.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)
@@ -312,7 +296,7 @@ class TestBeamlineModes(unittest.TestCase):
         initial_s2_height = 0.0
         target_s2_height = 1.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)
@@ -333,7 +317,7 @@ class TestBeamlineModes(unittest.TestCase):
         initial_s2_height = 0.0
         target_s2_height = 1.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)
@@ -344,18 +328,18 @@ class TestBeamlineModes(unittest.TestCase):
         beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
         beamline.active_mode = empty_mode
 
-        sm_angle.sp_no_move = 20.0
+        sm_angle.sp_no_move = 22.5
         slit2_pos.sp_no_move = target_s2_height
         beamline.move = 1
 
         assert_that(s2.sp_position().y, is_(target_s2_height))
 
-    def test_GIVEN_parameter_changed_and_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(
+    def test_GIVEN_parameter_changed_and_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp_and_following_parameters_offset(
             self):
         initial_s2_height = 0.0
         target_s2_height = 1.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
-        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+        s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
         sm_angle = ReflectionAngle("smangle", super_mirror)
         slit2_pos = TrackingPosition("slit2pos", s2)

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -315,7 +315,7 @@ class TestBeamlineModes(unittest.TestCase):
     def test_GIVEN_parameter_changed_and_not_in_mode_and_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(
             self):
         initial_s2_height = 0.0
-        target_s2_height = 1.0
+        target_s2_height = 11.0
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
         s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
@@ -329,12 +329,12 @@ class TestBeamlineModes(unittest.TestCase):
         beamline.active_mode = empty_mode
 
         sm_angle.sp_no_move = 22.5
-        slit2_pos.sp_no_move = target_s2_height
+        slit2_pos.sp_no_move = 1.0
         beamline.move = 1
 
-        assert_that(s2.sp_position().y, is_(target_s2_height))
+        assert_that(s2.sp_position().y, is_(close_to(target_s2_height, DEFAULT_TEST_TOLERANCE)))
 
-    def test_GIVEN_parameter_changed_and_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp_and_following_parameters_offset(
+    def test_GIVEN_parameter_changed_and_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(
             self):
         initial_s2_height = 0.0
         target_s2_height = 1.0

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -279,8 +279,8 @@ class TestBeamlineModes(unittest.TestCase):
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
         s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
-        sm_angle = ReflectionAngle("smangle", super_mirror)
-        slit2_pos = TrackingPosition("slit2pos", s2)
+        sm_angle = ReflectionAngle("smangle", super_mirror, True)
+        slit2_pos = TrackingPosition("slit2pos", s2, True)
 
         mode = BeamlineMode("both_params", [sm_angle.name, slit2_pos.name])
 
@@ -341,8 +341,8 @@ class TestBeamlineModes(unittest.TestCase):
         super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
         s2 = PassiveComponent("s2", LinearMovement(initial_s2_height, 20, 90.0))
 
-        sm_angle = ReflectionAngle("smangle", super_mirror)
-        slit2_pos = TrackingPosition("slit2pos", s2)
+        sm_angle = ReflectionAngle("smangle", super_mirror, True)
+        slit2_pos = TrackingPosition("slit2pos", s2, True)
 
         mode = BeamlineMode("both_params", [sm_angle.name, slit2_pos.name])
 

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -253,6 +253,123 @@ class TestBeamlineModes(unittest.TestCase):
         with self.assertRaises(KeyError):
             beamline.active_mode = beamline_mode
 
+    def test_GIVEN_parameter_not_in_mode_and_not_changed_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
+        initial_s2_height = 0.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        empty_mode = BeamlineMode("empty", [])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle,slit2_pos], [empty_mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = empty_mode
+
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(initial_s2_height))
+
+    def test_GIVEN_parameter_not_in_mode_and_not_changed_and_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
+        initial_s2_height = 0.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        mode = BeamlineMode("first_param", [sm_angle.name])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle, slit2_pos], [mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = mode
+        sm_angle.sp_no_move = 10.0
+
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(initial_s2_height))
+
+    def test_GIVEN_parameter_in_mode_and_not_changed_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_unchanged(self):
+        initial_s2_height = 0.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        mode = BeamlineMode("both_params", [sm_angle.name, slit2_pos.name])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle, slit2_pos], [mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = mode
+
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(initial_s2_height))
+
+    def test_GIVEN_parameter_changed_and_not_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(self):
+        initial_s2_height = 0.0
+        target_s2_height = 1.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        empty_mode = BeamlineMode("empty", [])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle, slit2_pos], [empty_mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = empty_mode
+
+        slit2_pos.sp_no_move = target_s2_height
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(target_s2_height))
+
+    def test_GIVEN_parameter_changed_and_not_in_mode_and_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(
+            self):
+        initial_s2_height = 0.0
+        target_s2_height = 1.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        empty_mode = BeamlineMode("empty", [])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle, slit2_pos], [empty_mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = empty_mode
+
+        sm_angle.sp_no_move = 20.0
+        slit2_pos.sp_no_move = target_s2_height
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(target_s2_height))
+
+    def test_GIVEN_parameter_changed_and_in_mode_and_no_previous_parameter_changed_WHEN_moving_beamline_THEN_parameter_moved_to_sp(
+            self):
+        initial_s2_height = 0.0
+        target_s2_height = 1.0
+        super_mirror = ActiveComponent("sm", LinearMovement(0.0, 10, 90.0))
+        s2 = PassiveComponent("det", LinearMovement(initial_s2_height, 20, 90.0))
+
+        sm_angle = ReflectionAngle("smangle", super_mirror)
+        slit2_pos = TrackingPosition("slit2pos", s2)
+
+        mode = BeamlineMode("both_params", [sm_angle.name, slit2_pos.name])
+
+        beamline = Beamline([super_mirror, s2], [sm_angle, slit2_pos], [mode])
+        beamline.set_incoming_beam(PositionAndAngle(0, 0, 0))
+        beamline.active_mode = mode
+
+        slit2_pos.sp_no_move = target_s2_height
+        beamline.move = 1
+
+        assert_that(s2.sp_position().y, is_(target_s2_height))
 
 class TestBeamlineOnMove(unittest.TestCase):
 


### PR DESCRIPTION
Created an IOC for the reflectometry server using PCASpy. This allows interaction with the reflectometry simulation by providing the following PVs:
* `$(PREFIX):REF:BL:MODE` - for setting the beamline mode
* `$(PREFIX):REF:BL:MOVE` -  for triggering a move on the whole beamline
* Various PVs for each beamline parameter
    * `$(PREFIX):REF:PARAM:$(PARAM_ALIAS)` - for the readback value (not hooked up as readbacks are not yet implemented)
    * `$(PREFIX):REF:PARAM:$(PARAM_ALIAS):SP` - for the setpoint (param will move to this value on next `move` instruction
    * `$(PREFIX):REF:PARAM:$(PARAM_ALIAS):SP:RBV` - for the setpoint readback (param has moved to this value on the last `move` instruction
    * `$(PREFIX):REF:PARAM:$(PARAM_ALIAS):MOVE` - for triggering a `move` on this parameter only
    * `$(PREFIX):REF:PARAM:$(PARAM_ALIAS):SETANDMOVE` - set the SP and move to it immediately

A simulated instrument can be started up by running `sim_ioc.py` 


#### Also in this pull request:
* The `Beamline` knows which modes are available and provides a lookup (same as with parameters)
* Parameter values can be initialised by setting a `sim` parameter when instantiating
* Added tests for cases of calling `move` not previously covered

Original ticket: https://github.com/ISISComputingGroup/IBEX/issues/3390