### PR TITLE
Ioc driving layer

### DIFF
--- a/example_beamline.py
+++ b/example_beamline.py
@@ -23,7 +23,8 @@ def create_beamline():
     theta = Theta("theta", ideal_sample_point)
     beamline = Beamline(
         [s0, s1, frame_overlap_mirror, polarising_mirror, s2, ideal_sample_point, s3, analyser, s4, detector],
-        [theta])
+        [theta],
+        [])
     beamline.set_incoming_beam(beam_start)
     beamline.mode = BeamlineMode("NR", ["theta"])
 

--- a/src/beamline.py
+++ b/src/beamline.py
@@ -65,7 +65,7 @@ class Beamline(object):
     The collection of all beamline components.
     """
 
-    def __init__(self, components, beamline_parameters, drivers=[]):
+    def __init__(self, components, beamline_parameters, drivers):
         """
         The initializer.
         Args:

--- a/src/ioc_driver.py
+++ b/src/ioc_driver.py
@@ -15,10 +15,10 @@ class IocDriver(object):
         """
         raise NotImplemented()
 
-    def perform_move(self, duration):
+    def perform_move(self, move_duration):
         """
         This should be overridden in the subclass. Tells the driver to perform a move to the component setpoints within a given duration
-        :param duration: The duration in which to perform this move
+        :param move_duration: The duration in which to perform this move
         """
         raise NotImplemented()
 
@@ -28,32 +28,76 @@ class HeightDriver(IocDriver):
     Drives a component with vertical movement
     """
     def __init__(self, component, height_axis):
+        """
+        Constructor.
+        :param component (src.components.PassiveComponent): The component providing the values for the IOC
+        :param height_axis: The PV that this driver controls.
+        """
         super(HeightDriver, self).__init__(component)
         self._height_axis = height_axis
 
-    def get_max_move_duration(self):
-        return math.fabs(self._height_axis.value - self._component.sp_position().y) / self._height_axis.max_velocity
+    def _get_distance_height(self):
+        """
+        :return: The distance between the target component position and the actual motor position in y.
+        """
+        return math.fabs(self._height_axis.value - self._component.sp_position().y)
 
-    def perform_move(self, duration):
-        self._height_axis.velocity = math.fabs(self._height_axis.value - self._component.sp_position().y) / duration
+    def get_max_move_duration(self):
+        """
+        :return: The expected duration of the current move based on the distance between the current value, setpoint value and maximum move velocity.
+        """
+        return self._get_distance_height() / self._height_axis.max_velocity
+
+    def perform_move(self, move_duration):
+        """
+        Tells the height axis to move to the setpoint within a given time frame.
+        :param duration (float): The desired duration of the move.
+        """
+        self._height_axis.velocity = self._get_distance_height() / move_duration
         self._height_axis.value = self._component.sp_position().y
 
 
 class HeightAndTiltDriver(HeightDriver):
     """
-    Drives a tilting jawset
+    Drives a component that has variable tilt in order to stay perpendicular to the beam in addition to variable height.
     """
+
+    ANGULAR_OFFSET = 90.0
+
     def __init__(self, component, height_axis, tilt_axis):
         super(HeightAndTiltDriver, self).__init__(component, height_axis)
         self._tilt_axis = tilt_axis
 
+    def _target_angle_perpendicular(self):
+        return self._component.calculate_tilt_angle() - self.ANGULAR_OFFSET
+
     def get_max_move_duration(self):
-        vertical_move_duration = math.fabs(self._height_axis.value - self._component.sp_position().y) / self._height_axis.max_velocity
-        angular_move_duration = math.fabs(self._tilt_axis.value - self._component.calculate_tilt_angle()) / self._tilt_axis.max_velocity
+        vertical_move_duration = self._get_distance_height() / self._height_axis.max_velocity
+        angular_move_duration = math.fabs(self._tilt_axis.value - self._target_angle_perpendicular()) / self._tilt_axis.max_velocity
         return max(vertical_move_duration, angular_move_duration)
 
-    def perform_move(self, duration):
-        self._height_axis.velocity = math.fabs(self._height_axis.value - self._component.sp_position().y) / duration
-        self._tilt_axis.velocity = math.fabs(self._tilt_axis.value - self._component.calculate_tilt_angle()) / duration
+    def perform_move(self, move_duration):
+        self._height_axis.velocity = self._get_distance_height() / move_duration
+        self._tilt_axis.velocity = math.fabs(self._tilt_axis.value - self._target_angle_perpendicular()) / move_duration
         self._height_axis.value = self._component.sp_position().y
         self._tilt_axis.value = self._component.calculate_tilt_angle()
+
+
+class HeightAndAngleDriver(HeightDriver):
+    """
+    Drives a component that has variable height and angle.
+    """
+    def __init__(self, component, height_axis, angle_axis):
+        super(HeightAndAngleDriver, self).__init__(component, height_axis)
+        self._angle_axis = angle_axis
+
+    def get_max_move_duration(self):
+        vertical_move_duration = math.fabs(self._height_axis.value - self._component.sp_position().y) / self._height_axis.max_velocity
+        angular_move_duration = math.fabs(self._angle_axis.value - self._component.angle) / self._angle_axis.max_velocity
+        return max(vertical_move_duration, angular_move_duration)
+
+    def perform_move(self, move_duration):
+        self._height_axis.velocity = math.fabs(self._height_axis.value - self._component.sp_position().y) / move_duration
+        self._angle_axis.velocity = math.fabs(self._angle_axis.value - self._component.angle) / move_duration
+        self._height_axis.value = self._component.sp_position().y
+        self._angle_axis.value = self._component.angle

--- a/src/ioc_driver.py
+++ b/src/ioc_driver.py
@@ -1,3 +1,7 @@
+"""
+The driving layer communicates between the component layer and underlying pvs.
+"""
+
 import math
 
 
@@ -82,7 +86,8 @@ class HeightAndTiltDriver(HeightDriver):
         :return: The expected duration of a move based on move distance and axis speed for the slowest axis.
         """
         vertical_move_duration = self._get_distance_height() / self._height_axis.max_velocity
-        angular_move_duration = math.fabs(self._tilt_axis.value - self._target_angle_perpendicular()) / self._tilt_axis.max_velocity
+        distance_to_move = math.fabs(self._tilt_axis.value - self._target_angle_perpendicular())
+        angular_move_duration = distance_to_move / self._tilt_axis.max_velocity
         return max(vertical_move_duration, angular_move_duration)
 
     def perform_move(self, move_duration):
@@ -114,8 +119,10 @@ class HeightAndAngleDriver(HeightDriver):
         """
         :return: The expected duration of a move based on move distance and axis speed for the slowest axis.
         """
-        vertical_move_duration = math.fabs(self._height_axis.value - self._component.sp_position().y) / self._height_axis.max_velocity
-        angular_move_duration = math.fabs(self._angle_axis.value - self._component.angle) / self._angle_axis.max_velocity
+        height_to_move = math.fabs(self._height_axis.value - self._component.sp_position().y)
+        vertical_move_duration = height_to_move / self._height_axis.max_velocity
+        angle_to_move = math.fabs(self._angle_axis.value - self._component.angle)
+        angular_move_duration = angle_to_move / self._angle_axis.max_velocity
         return max(vertical_move_duration, angular_move_duration)
 
     def perform_move(self, move_duration):
@@ -123,7 +130,8 @@ class HeightAndAngleDriver(HeightDriver):
         Tells the height and angle axes to move to the setpoint within a given time frame.
         :param move_duration: The desired duration of the move.
         """
-        self._height_axis.velocity = math.fabs(self._height_axis.value - self._component.sp_position().y) / move_duration
+        height_to_move = math.fabs(self._height_axis.value - self._component.sp_position().y)
+        self._height_axis.velocity = height_to_move / move_duration
         self._angle_axis.velocity = math.fabs(self._angle_axis.value - self._component.angle) / move_duration
         self._height_axis.value = self._component.sp_position().y
         self._angle_axis.value = self._component.angle

--- a/src/motor_pv_wrapper.py
+++ b/src/motor_pv_wrapper.py
@@ -1,7 +1,7 @@
 from genie_python.genie_cachannel_wrapper import CaChannelWrapper
 
 
-class PVWrapper(object):
+class MotorPVWrapper(object):
     def __init__(self, pv_name):
         """
         Creates a wrapper around a motor PV for accessing its fields.
@@ -37,9 +37,9 @@ class PVWrapper(object):
         """
         Returns: the value of the underlying PV
         """
-        return CaChannelWrapper.get_pv_value(self._pv_name + ".VELO")
+        return CaChannelWrapper.get_pv_value(self._pv_name + ".VMAX")
 
-    @value.setter
+    @velocity.setter
     def velocity(self, value):
         """
         Writes a value to the underlying PV's VAL field.

--- a/src/pv_wrapper.py
+++ b/src/pv_wrapper.py
@@ -1,0 +1,49 @@
+from genie_python.genie_cachannel_wrapper import CaChannelWrapper
+
+
+class PVWrapper(object):
+    def __init__(self, pv_name):
+        """
+        Creates a wrapper around a motor PV for accessing its fields.
+        :param pv_name (string): The name of the PV
+        """
+        self._pv_name = pv_name
+
+    @property
+    def name(self):
+        """
+        Returns: the name of the underlying PV
+        """
+        return self._pv_name
+
+    @property
+    def value(self):
+        """
+        Returns: the value of the underlying PV
+        """
+        return CaChannelWrapper.get_pv_value(self._pv_name)
+
+    @value.setter
+    def value(self, value):
+        """
+        Writes a value to the underlying PV's VAL field.
+        Args:
+            value: The value to set
+        """
+        CaChannelWrapper.set_pv_value(self._pv_name, value)
+
+    @property
+    def velocity(self):
+        """
+        Returns: the value of the underlying PV
+        """
+        return CaChannelWrapper.get_pv_value(self._pv_name + ".VELO")
+
+    @value.setter
+    def velocity(self, value):
+        """
+        Writes a value to the underlying PV's VAL field.
+        Args:
+            value: The value to set
+        """
+        CaChannelWrapper.set_pv_value(self._pv_name + ".VELO", value)

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -33,6 +33,6 @@ class DataMother(object):
         two = EmptyBeamlineParameter("two")
         three = EmptyBeamlineParameter("three")
         beamline_parameters = [one, two, three]
-        beamline = Beamline([], beamline_parameters)
+        beamline = Beamline([], beamline_parameters, [])
         beamline.mode = BeamlineMode("all", [beamline_parameter.name for beamline_parameter in beamline_parameters])
         return beamline_parameters, beamline

--- a/tests/data_mother.py
+++ b/tests/data_mother.py
@@ -23,7 +23,7 @@ class DataMother(object):
         ["slit2height", "height", "theta", "detectorheight"])
 
     @staticmethod
-    def beamline_with_3_empty_patameters():
+    def beamline_with_3_empty_parameters():
         """
 
         Returns: a beamline with three empty parameters, all in a mode

--- a/tests/test_actual_positions.py
+++ b/tests/test_actual_positions.py
@@ -32,7 +32,8 @@ class TestComponentBeamline(unittest.TestCase):
         smangle.sp = 0
         self.beamline = Beamline(
             [s0, s1, frame_overlap_mirror, self.polarising_mirror, s2, self.ideal_sample_point, s3, analyser, s4, detector],
-            [smangle, theta])
+            [smangle, theta],
+            [])
         self.beamline.set_incoming_beam(beam_start)
         self.nr_mode = BeamlineMode("NR Mode", [theta.name])
         self.polarised_mode = BeamlineMode("NR Mode", [smangle.name, theta.name])

--- a/tests/test_beamline.py
+++ b/tests/test_beamline.py
@@ -15,14 +15,14 @@ class TestComponentBeamline(unittest.TestCase):
         mirror = ActiveComponent("mirror", movement_strategy=LinearMovement(0, mirror_position, 90))
         mirror.angle = initial_mirror_angle
         jaws3 = PassiveComponent("jaws3", movement_strategy=LinearMovement(0, 20, 90))
-        beamline = Beamline([jaws, mirror, jaws3], {})
+        beamline = Beamline([jaws, mirror, jaws3], [], [])
         beamline.set_incoming_beam(beam_start)
         return beamline, mirror
 
     def test_GIVEN_beam_line_contains_one_passive_component_WHEN_beam_set_THEN_component_has_beam_out_same_as_beam_in(self):
         beam_start = PositionAndAngle(y=0, z=0, angle=0)
         jaws = PassiveComponent("jaws", movement_strategy=LinearMovement(0, 2, 90))
-        beamline = Beamline([jaws], {})
+        beamline = Beamline([jaws], [], [])
         beamline.set_incoming_beam(beam_start)
 
         result = beamline[0].get_outgoing_beam()

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -247,7 +247,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(calling(Beamline).with_args([], [one, two]), raises(ValueError))
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_1st_THEN_all_move(self):
-        beamline_parameters, _ = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()
 
         beamline_parameters[0].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
@@ -255,7 +255,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(moves, contains(1, 1, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_2nd_THEN_2nd_and_3rd_move(self):
-        beamline_parameters, _ = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()
 
         beamline_parameters[1].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
@@ -263,7 +263,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(moves, contains(0, 1, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_3rd_THEN_3rd_moves(self):
-        beamline_parameters, _ = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()
 
         beamline_parameters[2].move = 1
         moves = [beamline_parameter.move_component_count for beamline_parameter in beamline_parameters]
@@ -271,7 +271,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(moves, contains(0, 0, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_and_1_and_3_in_mode_WHEN_move_1st_THEN_parameters_in_the_mode_move(self):
-        beamline_parameters, beamline = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
         beamline.mode = BeamlineMode("all", [beamline_parameters[0].name, beamline_parameters[2].name])
 
         beamline_parameters[0].move = 1
@@ -280,7 +280,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(moves, contains(1, 0, 1), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_and_3_in_mode_WHEN_move_1st_THEN_only_2nd_parameter_moved(self):
-        beamline_parameters, beamline = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
         beamline.mode = BeamlineMode("all", [beamline_parameters[2].name])
 
         beamline_parameters[0].move = 1
@@ -289,7 +289,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         assert_that(moves, contains(1, 0, 0), "beamline parameter move counts")
 
     def test_GIVEN_three_beamline_parameters_in_mode_WHEN_1st_changed_and_move_beamline_THEN_all_move(self):
-        beamline_parameters, beamline = DataMother.beamline_with_3_empty_patameters()
+        beamline_parameters, beamline = DataMother.beamline_with_3_empty_parameters()
 
         beamline_parameters[0].sp = 12.0
         beamline.move = 1

--- a/tests/test_beamline_parameter.py
+++ b/tests/test_beamline_parameter.py
@@ -141,7 +141,7 @@ class TestBeamlineModes(unittest.TestCase):
             TrackingPosition("detectorheight", detector)]
                       #parameters["detectorAngle": TrackingAngle(detector)
         beam = PositionAndAngle(0, 0, -45)
-        beamline = Beamline(components, parameters)
+        beamline = Beamline(components, parameters, [])
         beamline.mode = DataMother.BEAMLINE_MODE_NEUTRON_REFLECTION
         beamline.parameter("theta").sp = 45
         beamline.parameter("height").sp = 0
@@ -160,7 +160,7 @@ class TestBeamlineModes(unittest.TestCase):
         ideal_sample_point = ActiveComponent("ideal_sample_point", LinearMovement(y_position=0, z_position=20, angle=90))
         theta = Theta("theta", ideal_sample_point)
         beamline_mode = BeamlineMode("mode name", [theta.name])
-        beamline = Beamline([ideal_sample_point], [theta])
+        beamline = Beamline([ideal_sample_point], [theta], [])
         beam = PositionAndAngle(0, 0, 0)
 
         theta.sp = angle_to_set
@@ -176,7 +176,7 @@ class TestBeamlineModes(unittest.TestCase):
         theta = Theta("theta", ideal_sample_point)
         beamline_mode = BeamlineMode("mode name", [])
         ideal_sample_point.angle = 0
-        beamline = Beamline([ideal_sample_point], [theta])
+        beamline = Beamline([ideal_sample_point], [theta], [])
         beam = PositionAndAngle(0, 0, 0)
 
         theta.sp = angle_to_set
@@ -194,7 +194,7 @@ class TestBeamlineModes(unittest.TestCase):
         smangle = ReflectionAngle("smangle", super_mirror)
 
         beamline_mode = BeamlineMode("mode name", [theta.name, smangle.name])
-        beamline = Beamline([super_mirror, ideal_sample_point], [smangle, theta])
+        beamline = Beamline([super_mirror, ideal_sample_point], [smangle, theta], [])
         beam = PositionAndAngle(0, 0, 0)
         theta.sp = angle_to_set
         smangle.sp = 0
@@ -216,7 +216,7 @@ class TestBeamlineModes(unittest.TestCase):
         smangle.sp = sm_angle
         sp_inits = {smangle.name: sm_angle_to_set}
         beamline_mode = BeamlineMode("mode name", [smangle.name], sp_inits)
-        beamline = Beamline([super_mirror], [smangle])
+        beamline = Beamline([super_mirror], [smangle], [])
 
         beamline.mode = beamline_mode
 
@@ -232,7 +232,7 @@ class TestBeamlineModes(unittest.TestCase):
         smangle.sp = sm_angle
         sp_inits = {"nonsense name": sm_angle}
         beamline_mode = BeamlineMode("mode name", [smangle.name], sp_inits)
-        beamline = Beamline([super_mirror], [smangle])
+        beamline = Beamline([super_mirror], [smangle], [])
 
         with self.assertRaises(KeyError):
             beamline.mode = beamline_mode
@@ -244,7 +244,7 @@ class TestBeamlineOnMove(unittest.TestCase):
         one = EmptyBeamlineParameter("same")
         two = EmptyBeamlineParameter("same")
 
-        assert_that(calling(Beamline).with_args([], [one, two]), raises(ValueError))
+        assert_that(calling(Beamline).with_args([], [one, two], []), raises(ValueError))
 
     def test_GIVEN_three_beamline_parameters_WHEN_move_1st_THEN_all_move(self):
         beamline_parameters, _ = DataMother.beamline_with_3_empty_parameters()

--- a/tests/test_ioc_driving_layer.py
+++ b/tests/test_ioc_driving_layer.py
@@ -1,13 +1,22 @@
 import unittest
 from math import fabs
-from mock import MagicMock, PropertyMock
+from mock import MagicMock, PropertyMock, patch
 from hamcrest import *
 
-from src.components import PassiveComponent, TiltingJaws, LinearMovement, PositionAndAngle
-from src.ioc_driver import HeightDriver, HeightAndTiltDriver
-
+from src.components import PassiveComponent, ActiveComponent, TiltingJaws, LinearMovement, PositionAndAngle
+from src.ioc_driver import HeightDriver, HeightAndTiltDriver, HeightAndAngleDriver
+from src.beamline import Beamline, BeamlineMode
+from src.parameters import ReflectionAngle, TrackingPosition
 
 FLOAT_TOLERANCE = 1e-9
+
+
+def create_mock_axis(name, init_position, max_velocity):
+    axis = MagicMock()
+    axis.name = name
+    axis.value = init_position
+    axis.max_velocity = max_velocity
+    return axis
 
 
 class TestHeightDriver(unittest.TestCase):
@@ -15,10 +24,7 @@ class TestHeightDriver(unittest.TestCase):
     def setUp(self):
         start_position = 0.0
         max_velocity = 10.0
-        self.height_axis = MagicMock()
-        self.height_axis.name = "JAWS:HEIGHT"
-        self.height_axis.value = start_position
-        self.height_axis.max_velocity = max_velocity
+        self.height_axis = create_mock_axis("JAWS:HEIGHT", start_position, max_velocity)
 
         self.jaws = PassiveComponent("component", movement_strategy=LinearMovement(0.0, 10.0, 90.0))
         self.jaws.set_incoming_beam(PositionAndAngle(0.0, 0.0, 0.0))
@@ -68,30 +74,23 @@ class TestHeightAndTiltDriver(unittest.TestCase):
     def setUp(self):
         start_position_height = 0.0
         max_velocity_height = 10.0
-        self.height_axis = MagicMock()
-        self.height_axis.name = "JAWS:HEIGHT"
-        self.height_axis.value = start_position_height
-        self.height_axis.max_velocity = max_velocity_height
+        self.height_axis = create_mock_axis("JAWS:HEIGHT", start_position_height, max_velocity_height)
 
-        start_position_tilt = 90.0
+        start_position_tilt = 0.0
         max_velocity_tilt = 10.0
-        self.tilt_axis = MagicMock()
-        self.tilt_axis.name = "JAWS:TILT"
-        self.tilt_axis.value = start_position_tilt
-        self.tilt_axis.max_velocity = max_velocity_tilt
+        self.tilt_axis = create_mock_axis("JAWS:TILT", start_position_tilt, max_velocity_tilt)
 
         self.tilting_jaws = TiltingJaws("component", movement_strategy=LinearMovement(0.0, 10.0, 90.0))
 
-        self.jaws_driver = HeightAndTiltDriver(self.tilting_jaws, self.height_axis, self.tilt_axis)
+        self.tilting_jaws_driver = HeightAndTiltDriver(self.tilting_jaws, self.height_axis, self.tilt_axis)
 
     def test_GIVEN_multiple_axes_need_to_move_WHEN_computing_move_duration_THEN_maximum_duration_is_returned(self):
         beam_angle = 45.0
         expected = 4.5
         beam = PositionAndAngle(0.0, 0.0, beam_angle)
         self.tilting_jaws.set_incoming_beam(beam)
-        self.tilting_jaws.set_position_relative_to_beam(0.0)  # move component into beam
 
-        result = self.jaws_driver.get_max_move_duration()
+        result = self.tilting_jaws_driver.get_max_move_duration()
 
         assert_that(result, is_(expected))
 
@@ -106,7 +105,7 @@ class TestHeightAndTiltDriver(unittest.TestCase):
         self.tilting_jaws.set_incoming_beam(beam)
         self.tilting_jaws.set_position_relative_to_beam(0.0)  # move component into beam
 
-        self.jaws_driver.perform_move(target_duration)
+        self.tilting_jaws_driver.perform_move(target_duration)
 
         assert_that(fabs(self.height_axis.velocity - expected_velocity_height) <= FLOAT_TOLERANCE)
         assert_that(fabs(self.height_axis.value - target_position_height) <= FLOAT_TOLERANCE)
@@ -116,3 +115,92 @@ class TestHeightAndTiltDriver(unittest.TestCase):
     # TODO ???
     def test_GIVEN_target_move_duration_too_short_WHEN_moving_axes_THEN_complain(self):
         pass
+
+
+class TestHeightAndAngleDriver(unittest.TestCase):
+    def setUp(self):
+        start_position_height = 0.0
+        max_velocity_height = 10.0
+        self.height_axis = create_mock_axis("SM:HEIGHT", start_position_height, max_velocity_height)
+
+        start_position_angle = 0.0
+        max_velocity_angle = 10.0
+        self.angle_axis = create_mock_axis("SM:ANGLE", start_position_angle, max_velocity_angle)
+
+        self.supermirror = ActiveComponent("component", movement_strategy=LinearMovement(0.0, 10.0, 90.0))
+        self.supermirror.set_incoming_beam(PositionAndAngle(0.0, 0.0, 0.0))
+
+        self.supermirror_driver = HeightAndAngleDriver(self.supermirror, self.height_axis, self.angle_axis)
+
+    def test_GIVEN_multiple_axes_need_to_move_WHEN_computing_move_duration_THEN_maximum_duration_is_returned(self):
+        target_angle = 30.0
+        expected = 3.0
+        self.supermirror.angle = target_angle
+        self.supermirror.set_position_relative_to_beam(10.0)
+
+        result = self.supermirror_driver.get_max_move_duration()
+
+        assert_that(result, is_(expected))
+
+    def test_GIVEN_move_duration_and_target_position_set_WHEN_moving_multiple_axes_THEN_computed_axis_velocity_is_correct_and_setpoint_set_for_all_axes(
+            self):
+        target_duration = 10.0
+        expected_velocity_height = 1.0
+        target_position_height = 10.0
+        expected_velocity_angle = 3.0
+        target_position_angle = 30.0
+        self.supermirror.angle = 30.0
+        self.supermirror.set_position_relative_to_beam(10.0)  # move component into beam
+
+        self.supermirror_driver.perform_move(target_duration)
+
+        assert_that(fabs(self.height_axis.velocity - expected_velocity_height) <= FLOAT_TOLERANCE)
+        assert_that(fabs(self.height_axis.value - target_position_height) <= FLOAT_TOLERANCE)
+        assert_that(fabs(self.angle_axis.velocity - expected_velocity_angle) <= FLOAT_TOLERANCE)
+        assert_that(fabs(self.angle_axis.value - target_position_angle) <= FLOAT_TOLERANCE)
+
+
+class BeamlineMoveDurationTest(unittest.TestCase):
+    def test_GIVEN_multiple_components_in_beamline_WHEN_triggering_move_THEN_components_move_at_speed_of_slowest_axis(self):
+        sm_angle = 0.0
+        sm_angle_to_set = 22.5
+        supermirror = ActiveComponent("supermirror", movement_strategy=LinearMovement(y_position=0.0, z_position=10.0, angle=90.0))
+        sm_height_axis = create_mock_axis("SM:HEIGHT", 0.0, 10.0)
+        sm_angle_axis = create_mock_axis("SM:ANGLE", sm_angle, 10.0)
+        supermirror.angle = sm_angle
+        supermirror_driver = HeightAndAngleDriver(supermirror, sm_height_axis, sm_angle_axis)
+
+        slit_2 = PassiveComponent("slit_2", movement_strategy=LinearMovement(y_position=0.0, z_position=20.0, angle=90.0))
+        slit_2_height_axis = create_mock_axis("SLIT2:HEIGHT", 0.0, 10.0)
+        slit_2_driver = HeightDriver(slit_2, slit_2_height_axis)
+
+        slit_3 = PassiveComponent("slit_3", movement_strategy=LinearMovement(y_position=0.0, z_position=30.0, angle=90.0))
+        slit_3_height_axis = create_mock_axis("SLIT3:HEIGHT", 0.0, 10.0)
+        slit_3_driver = HeightDriver(slit_3, slit_3_height_axis)
+
+        detector = TiltingJaws("jaws", movement_strategy=LinearMovement(y_position=0.0, z_position=40.0, angle=90.0))
+        detector_height_axis = create_mock_axis("DETECTOR:HEIGHT", 0.0, 10.0)
+        detector_tilt_axis = create_mock_axis("DETECTOR:TILT", 0.0, 10.0)
+        detector_driver = HeightAndTiltDriver(detector, detector_height_axis, detector_tilt_axis)
+
+        smangle = ReflectionAngle("smangle", supermirror)
+        slit_2_pos = TrackingPosition("s2_pos", slit_2)
+        slit_3_pos = TrackingPosition("s3_pos", slit_3)
+        det_pos = TrackingPosition("det_pos", detector)
+        slit_2_pos.sp = 0.0
+        slit_3_pos.sp = 0.0
+        det_pos.sp = 0.0
+        beamline = Beamline([supermirror, slit_2, slit_3, detector], [smangle, slit_2_pos, slit_3_pos, det_pos], [supermirror_driver, slit_2_driver, slit_3_driver, detector_driver])
+        beamline.mode = BeamlineMode("mode name", [smangle.name, slit_2_pos.name, slit_3_pos.name, det_pos.name])
+
+        beam_start = PositionAndAngle(0.0, 0.0, 0.0)
+        beamline.set_incoming_beam(beam_start)
+
+        # detector angle axis takes longest
+        expected_max_duration = 4.5
+
+        smangle.sp = sm_angle_to_set
+        with patch.object(beamline, '_move_drivers') as mock:
+            beamline.move = 1
+
+            mock.assert_called_with(expected_max_duration)

--- a/tests/test_ioc_driving_layer.py
+++ b/tests/test_ioc_driving_layer.py
@@ -61,15 +61,6 @@ class TestHeightDriver(unittest.TestCase):
         assert_that(self.height_axis.value, is_(target_position))
 
 
-    # def test_GIVEN_component_has_not_changed_WHEN_moving_axis_THEN_no_pv_value_set(self):
-    #     prop =PropertyMock(return_value=0.0)
-    #     type(self.height_axis).value = prop
-    #
-    #     self.jaws_driver.perform_move(10.0)
-    #
-    #     prop.assert_not_called()
-    #
-
 class TestHeightAndTiltDriver(unittest.TestCase):
     def setUp(self):
         start_position_height = 0.0
@@ -111,10 +102,6 @@ class TestHeightAndTiltDriver(unittest.TestCase):
         assert_that(fabs(self.height_axis.value - target_position_height) <= FLOAT_TOLERANCE)
         assert_that(fabs(self.tilt_axis.velocity - expected_velocity_tilt) <= FLOAT_TOLERANCE)
         assert_that(fabs(self.tilt_axis.value - target_position_tilt) <= FLOAT_TOLERANCE)
-
-    # TODO ???
-    def test_GIVEN_target_move_duration_too_short_WHEN_moving_axes_THEN_complain(self):
-        pass
 
 
 class TestHeightAndAngleDriver(unittest.TestCase):


### PR DESCRIPTION
Implemented corresponding drivers for each type of component. A driver takes a component object and a wrapper object around a PV address providing some methods for getting position and velocity.

When triggering a beamline move, the `Beamline` model will first fetch the maximum move duration for all axes in all drivers, and then pass this duration as a parameter with the move instruction to each driver. The aim of this is to synchronise all motion per beamline move to stop at the same time as a way to avoid collisions.

Fixes: https://github.com/ISISComputingGroup/IBEX/issues/3456